### PR TITLE
Found issue (in logs) that caused remarks with partial reports to cau…

### DIFF
--- a/classification_tests.py
+++ b/classification_tests.py
@@ -33,6 +33,8 @@ def get_ceiling(metar):
       400
       >>> get_ceiling('KGCC 231853Z AUTO 28011KT 20/12 A2991 RMK AO2 LTG DSNT SE RAB41RAEMM SLP085 P0000 T02000117 PWINO $')
       10000
+      >>> get_ceiling('KVOK 251453Z 34004KT 10SM SCT008 OVC019 21/21 A2988 RMK AO2A SCT V BKN SLP119 53012')
+      1900
     """
 
     return weather.get_ceiling(metar)
@@ -62,6 +64,8 @@ def get_ceiling_classification(metar):
       'LIFR'
       >>> get_ceiling_classification(get_ceiling('KGCC 231853Z AUTO 28011KT 20/12 A2991 RMK AO2 LTG DSNT SE RAB41RAEMM SLP085 P0000 T02000117 PWINO $'))
       'VFR'
+      >>> get_ceiling_classification(get_ceiling('KVOK 251453Z 34004KT 10SM SCT008 OVC019 21/21 A2988 RMK AO2A SCT V BKN SLP119 53012'))
+      'MVFR'
     """
 
     return weather.get_ceiling_category(metar)
@@ -85,6 +89,8 @@ def get_visibilty(metar):
       >>> get_visibilty('KRNT 132053Z 33010KT 1/2SM SCT034 SCT041 23/14 A3001 RMK AO2 SLP165')
       'LIFR'
       >>> get_visibilty('KGCC 231853Z AUTO 28011KT 20/12 A2991 RMK AO2 LTG DSNT SE RAB41RAEMM SLP085 P0000 T02000117 PWINO $')
+      'VFR'
+      >>> get_visibilty('KVOK 251453Z 34004KT 10SM SCT008 OVC019 21/21 A2988 RMK AO2A SCT V BKN SLP119 53012')
       'VFR'
     """
     return weather.get_visibilty(metar)

--- a/controller.py
+++ b/controller.py
@@ -248,7 +248,7 @@ def get_airport_category(airport, metar, utc_offset):
                 airport, twilight[1] - utc_offset, twilight[4] - utc_offset))
         except Exception as e:
             LOGGER.log_warning_message(
-                "Exception while attempting to categorize {}. EX:{}".format(metar, e))
+                "Exception while attempting to categorize METAR:{} EX:{}".format(metar, e))
     except Exception as e:
         LOGGER.log_info_message(
             "Captured EX while attempting to get category for {} EX:{}".format(airport, e))


### PR DESCRIPTION
Fixes https://github.com/JohnMarzulli/categorical-sectional/issues/13

Reviewing logs found that this METAR caused an exception while being classified for ceiling, and thus was classified as "INVALID".

KVOK 251453Z 34004KT 10SM SCT008 OVC019 21/21 A2988 RMK AO2A SCT V BKN SLP119 53012
The source is that the remarks section had a SCT and BKN token without a value.

To avoid this:

Skip over RMK since they do not represent the current condition in regards to our classification.
Wrap the ceiling parsing into a try/except block and skip over in case of an error.