### PR TITLE
Add Option To Disable Blinking

### DIFF
--- a/configuration/configuration.py
+++ b/configuration/configuration.py
@@ -108,12 +108,45 @@ def __get_configuration__() -> dict:
 CONFIG = __get_configuration__()
 
 
+def __get_boolean_config_value__(
+    config_key: str,
+    default: bool = False
+) -> bool:
+    """
+    Get a configuration value from the config that is a boolean.
+    If the value is not in the config, then use the default.
+
+    Arguments:
+        config_key {str} -- The name of the setting.
+        default {bool} -- The default value if the setting is not found.
+
+    Returns:
+        bool -- The value to use for the configuration.
+    """
+    try:
+        if CONFIG is not None and config_key in CONFIG:
+            return CONFIG[config_key]
+    except:
+        return default
+
+
 def get_mode():
     """
     Returns the mode given in the config.
     """
 
     return CONFIG['mode']
+
+
+def get_blink_station_if_old_data() -> bool:
+    """
+    Should old stations blink if the data is considered too old?
+
+    Returns:
+        bool -- Should the station be blinked if the data is too old?
+    """
+
+    return __get_boolean_config_value__('blink_old_stations', True)
 
 
 def get_night_lights():
@@ -124,12 +157,7 @@ def get_night_lights():
         boolean -- True if we should light airports that are in the dark
         differently.
     """
-
-    try:
-        if CONFIG is not None and 'night_lights' in CONFIG:
-            return CONFIG['night_lights']
-    except:
-        return False
+    return __get_boolean_config_value__('night_lights')
 
 
 def get_night_populated_yellow():
@@ -141,11 +169,7 @@ def get_night_populated_yellow():
     Returns:
         boolean -- True if the color of the station should be yellow when it is dark.
     """
-    try:
-        if CONFIG is not None and 'night_populated_yellow' in CONFIG:
-            return CONFIG['night_populated_yellow']
-    except:
-        return True
+    return __get_boolean_config_value__('night_populated_yellow', True)
 
 
 def get_night_category_proportion():

--- a/data/config.json
+++ b/data/config.json
@@ -5,6 +5,7 @@
   "spi_port": 0,
   "pwm_frequency": 100,
   "airports_file": "../data/kawo_to_kosh.json",
+  "blink_old_stations": true,
   "night_lights": true,
   "night_populated_yellow": false,
   "night_category_proportion": 0.05,

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ To complete the project you will need to supply your own chart and backing board
 
 Soldering is required for three (3) wires, along with some electrical tape.
 
-To finish the instalation you will need a monitor, and a keyboard.
+To finish the installation you will need a monitor, and a keyboard.
 
 #### Other Raspberry Pis
 
@@ -45,11 +45,41 @@ Barrel jack adapters                         | \$7.99  | <https://www.amazon.com
 Individually addressable LEDs (WS2801 based) | \$39.95 | <https://www.amazon.com/12mm-Diffused-Digital-Pixels-Strand/dp/B073MZWBYS/ref=sr_1_1?ie=UTF8&qid=1528558371&sr=8-1&keywords=adafruit+ws2801>
 4 Pin JST SM Plugs                           | \$7.99  | <https://www.amazon.com/Visdoll-Pairs-Female-Connector-Cable/dp/B075K48BD9/ref=sr_1_8?ie=UTF8&qid=1528559351&sr=8-8&keywords=4+Pin+JST+SM+Plug>
 
+### Upgrade Instructions
+
+If you have an older version of the software (V1.6 or earlier), it is highly recommended that you copy your configuration files into the user configuration directory.
+
+The user configuration files and directory are explained in the `~/weather_map/config.json` section.
+
+If you have not already migrated to a version that has the user configuration files, open a command line on the Raspberry Pi and execute the following commands:
+
+```bash
+cd ~/categorical-sectional
+mkdir ~/weather-map
+cp data/*.json ~/weather-map/
+```
+
+Please note that you may need to modify the value of `"airports_file"`. You will most like need to replace the `data/` portion with `~/weather-map/`
+
+For example: `"airports_file": "data/kawo_to_kosh.json"` would become `"airports_file": "~/weather-map/kawo_to_kosh.json"`
+
+Once you have performed this backup process and are sure that your files are in the new location, you may update the software.
+
+**WARNING**: The following steps will discard any modifications you have performed.
+
+```bash
+cd ~/categorical-sectional
+git fetch
+git reset --hard HEAD
+git checkout master
+git pull
+```
+
 ### Bootstrapping The Raspberry Pi
 
-#### OS Instalation
+#### OS Installation
 
-This section gets you started with instaling the software.
+This section gets you started with installing the software.
 
 A full tutorial on how to install the Operating System is available at: <https://www.raspberrypi.org/documentation/installation/noobs.md>
 
@@ -134,7 +164,7 @@ Green/Teal | 19                                          | MOSI
 - Connect the Male JST and LED connectors together.
 - Connect the barrel jack into the Neopixel strip.
 - Add the SD card to the Pi.
-- Plug inthe NeoPixels first, then the Raspberry Pi.
+- Plug in the NeoPixels first, then the Raspberry Pi.
 
 ## Understanding The Configuration Files
 
@@ -168,6 +198,7 @@ You do not need to include ALL of these values. Any values provided in this file
   "spi_port": 0,
   "pwm_frequency": 100,
   "airports_file": "data/kawo_to_kosh.json",
+  "blink_old_stations": true,
   "night_lights": true,
   "night_populated_yellow": false,
   "night_category_proportion": 0.05,
@@ -182,6 +213,7 @@ Here is an example of using overriding values:
 ```json
 {
   "airports_file": "~/weather_map/puget_sound_region.json",
+  "blink_old_stations": false,
   "night_category_proportion": 0.10,
   "brightness_proportion": 0.5
 }
@@ -189,9 +221,17 @@ Here is an example of using overriding values:
 
 In this example we are using the file `puget_sound_region.json` to define our mapping. This file is expected to be in the `/home/pi/weather_map` folder. We are also reducing the overall brightness (ever during the day) by 50% of what the lights are capable of.
 
+#### blink_old_stations
+
+Set this to `false` if you would like the stations to remain the last known category/color even if the data is old.
+
+The default is `true`. When the value is set to `true` any station with data older than 90 minutes will start blinking to indicate that the data is old.
+
+When new data is received that has an issue date less than 90 minutes from the current time, then the light will stop blinking.
+
 #### night_lights
 
-Set this to true if you would like the weather stations to change colors based on the time of day.
+Set this to `true` if you would like the weather stations to change colors based on the time of day.
 
 If you are using WS2801 or PWM based lights, then this is a gradual process.
 
@@ -201,11 +241,11 @@ In the morning, the light will increase back to a bright yellow as the office su
 
 #### night_populated_yellow
 
-Set this to true if you would like the day/night transition to show stations that are currently in "full dark" using yellow.
+Set this to `true` if you would like the day/night transition to show stations that are currently in "full dark" using yellow.
 
 This will transition/fade into yellow from the standard category color.
 
-Setting this to false will result in the category color fading. The amount the category fades is determined by `night_category_proportion`
+Setting this to `false` will result in the category color fading. The amount the category fades is determined by `night_category_proportion`
 
 #### night_category_proportion
 

--- a/readme.md
+++ b/readme.md
@@ -55,13 +55,13 @@ If you have not already migrated to a version that has the user configuration fi
 
 ```bash
 cd ~/categorical-sectional
-mkdir ~/weather-map
-cp data/*.json ~/weather-map/
+mkdir ~/weather_map
+cp data/*.json ~/weather_map/
 ```
 
-Please note that you may need to modify the value of `"airports_file"`. You will most like need to replace the `data/` portion with `~/weather-map/`
+Please note that you may need to modify the value of `"airports_file"`. You will most like need to replace the `data/` portion with `~/weather_map/`
 
-For example: `"airports_file": "data/kawo_to_kosh.json"` would become `"airports_file": "~/weather-map/kawo_to_kosh.json"`
+For example: `"airports_file": "data/kawo_to_kosh.json"` would become `"airports_file": "~/weather_map/kawo_to_kosh.json"`
 
 Once you have performed this backup process and are sure that your files are in the new location, you may update the software.
 
@@ -459,6 +459,7 @@ Error       | Blinking white | Blinking white | Blinking white
 
 Version | Change
 ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1.9     | Add documentation about the upgrade process for existing installations. Add configuration to control if old data causes a light to blink or not.
 1.8     | Use the configuration files provided as a default base, and then source user configuration from the user directory.
 1.7     | Allow for the brightness of the lights to be dimmed. This affects both the daytime and nighttime colors.
 1.6     | Updated documentation, wiring self-check file that uses the configuration to exercise each weather station for all colors.

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,18 @@
 import lib.local_debug as local_debug
 from setuptools import setup
 
-installs = ['pytest',
-            'Adafruit_WS2801',
-            'requests']
+installs = [
+    'pytest',
+    'Adafruit_WS2801',
+    'requests'
+]
 
 if not local_debug.is_debug():
     installs.append('RPi.GPIO')
 
 setup(
     name='cateorical-sectional',
-    version='1.8',
+    version='1.9',
     python_requires='>=3.5',
     description='VFR weathermap supporting Adafruit WS2801 lights.',
     url='https://github.com/JohnMarzulli/categorical-sectional',


### PR DESCRIPTION
Add an option that allows blinking of old stations to be turned on or off.

The default behavior is that stations with data older than 90 minutes blinks, and stations with data over 4.5 hours old turn off.